### PR TITLE
built out multiple serialization and deserialization options plus unit tests

### DIFF
--- a/src/JSON.Tests/JSONTest.cs
+++ b/src/JSON.Tests/JSONTest.cs
@@ -1,14 +1,21 @@
-using System.IO;
+using System.Text;
+using System.Text.Json;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using jmsudar.DotNet.JSON;
 
+/// <summary>
+/// Methods for testing JSON serialization and deserialization
+/// </summary>
 [TestClass]
 public class JsonMethodsTests
 {
+    /// <summary>
+    /// Test object containing string field, Name, and int field, Value
+    /// </summary>
     public class TestObject
     {
         public string Name { get; set; }
-        public int Value { get; set; }
+        public int? Value { get; set; }
     }
 
     /// <summary>
@@ -26,6 +33,22 @@ public class JsonMethodsTests
     }
 
     /// <summary>
+    /// Tests for properly indented JSON when prettify is set to true
+    /// </summary>
+    [TestMethod]
+    public void Serialize_WithWriteIndented_ReturnsFormattedJson()
+    {
+        var obj = new { Name = "Hello", Value = "World" };
+        // Expected format (indented JSON)
+        var expectedJson = $"{{{Environment.NewLine}  \"Name\": \"Hello\",{Environment.NewLine}  \"Value\": \"World\"{Environment.NewLine}}}";
+
+
+        var json = JsonMethods.Serialize(obj, true);
+
+        Assert.AreEqual(expectedJson, json);
+    }
+
+    /// <summary>
     /// Tests for successful exclusion of null fields
     /// </summary>
     [TestMethod]
@@ -33,9 +56,39 @@ public class JsonMethodsTests
     {
         var obj = new { Name = (string)null, Value = "World" };
 
-        var json = JsonMethods.Serialize(obj, true);
+        var json = JsonMethods.Serialize(obj, false, true);
 
         Assert.IsFalse(json.Contains("\"Name\""));
+    }
+
+    /// <summary>
+    /// Tests serializing an object to UTF-8 bytes
+    /// </summary>
+    [TestMethod]
+    public void SerializeToBytes_WithNonNullObject_ReturnsValidByteArray()
+    {
+        var obj = new { Name = "Hello", Value = "World" };
+        var expectedJson = "{\"Name\":\"Hello\",\"Value\":\"World\"}";
+
+        var resultBytes = JsonMethods.SerializeToBytes(obj);
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedJson);
+
+        CollectionAssert.AreEqual(expectedBytes, resultBytes);
+    }
+
+    /// <summary>
+    /// Tests serializing an object to UTF-8 bytes while excluding a null field
+    /// </summary>
+    [TestMethod]
+    public void SerializeToBytes_WithExcludeNullFields_ExcludesNulls()
+    {
+        var obj = new { Name = (string)null, Value = "World" };
+        var expectedJson = "{\"Value\":\"World\"}";
+
+        var resultBytes = JsonMethods.SerializeToBytes(obj, true);
+        var expectedBytes = Encoding.UTF8.GetBytes(expectedJson);
+
+        CollectionAssert.AreEqual(expectedBytes, resultBytes);
     }
 
     /// <summary>
@@ -50,6 +103,82 @@ public class JsonMethodsTests
 
         Assert.AreEqual("Widgets", obj.Name.ToString());
         Assert.AreEqual(100, (int)obj.Value);
+    }
+
+    /// <summary>
+    /// Tests deserialization of a UTF-8 byte array with types return objects
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_FromByteArray_ReturnsObjectOfType()
+    {
+        var json = "{\"Name\":\"Widgets\",\"Value\":100}";
+        var bytes = Encoding.UTF8.GetBytes(json);
+
+        var obj = JsonMethods.Deserialize<TestObject>(bytes);
+
+        Assert.AreEqual("Widgets", obj.Name.ToString());
+        Assert.AreEqual(100, (int)obj.Value);
+    }
+
+    /// <summary>
+    /// Tests successful deserialization with lowercase property names
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithCaseInsensitivePropertyNames_MatchesPropertiesCorrectly()
+    {
+        var json = "{\"name\":\"Widgets\",\"value\":100}"; // JSON with lower-case property names
+
+        // Default setting ignores casing
+        var obj = JsonMethods.Deserialize<TestObject>(json);
+
+        // Assert
+        Assert.IsNotNull(obj);
+        Assert.AreEqual("Widgets", obj.Name);
+        Assert.AreEqual(100, obj.Value);
+    }
+
+    /// <summary>
+    /// Tests unsuccessful deserialization when lowercase toggle is set to false
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithCaseSensitivePropertyNames_DoesNotMatchIncorrectCase()
+    {
+        var json = "{\"name\":\"Widgets\",\"value\":100}"; // JSON with lower-case property names
+
+        var obj = JsonMethods.Deserialize<TestObject>(json, false);
+
+        // Assert
+        Assert.IsNotNull(obj);
+        Assert.IsNull(obj.Name);
+        Assert.IsNull(obj.Value);
+    }
+
+    /// <summary>
+    /// Tests successful deserialization when trailing comma allowance defaults to true
+    /// </summary>
+    [TestMethod]
+    public void Deserialize_WithTrailingComma_AllowsWhenOptionIsTrue()
+    {
+        var json = "{\"Name\":\"Widgets\",\"Value\":100,}";
+
+        // Default setting allows trailing commas
+        var obj = JsonMethods.Deserialize<TestObject>(json);
+
+        Assert.IsNotNull(obj);
+        Assert.AreEqual("Widgets", obj.Name);
+        Assert.AreEqual(100, obj.Value);
+    }
+
+    /// <summary>
+    /// Tests unsuccessful deserialization when trailing comma allowance is set to false
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void Deserialize_WithTrailingComma_ThrowsExceptionWhenOptionIsFalse()
+    {
+        var json = "{\"Name\":\"Widgets\",\"Value\":100,}";
+
+        var obj = JsonMethods.Deserialize<TestObject>(json, true, false);
     }
 
     /// <summary>
@@ -69,5 +198,39 @@ public class JsonMethodsTests
 
         Assert.AreEqual("Widgets", obj.Name.ToString());
         Assert.AreEqual(100, (int)obj.Value);
+    }
+
+    /// <summary>
+    /// Tests successful exception throwing for deserializing a non-existent JSON file
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(FileNotFoundException))]
+    public void DeserializeFromFile_NonExistentFile_ThrowsFileNotFoundException()
+    {
+        var nonExistentFilePath = "nonexistentfile.json";
+
+        // This should throw FileNotFoundException
+        JsonMethods.DeserializeFromFile<TestObject>(nonExistentFilePath);
+    }
+
+    /// <summary>
+    /// Tests successful exception throwing for an invalid JSON error
+    /// </summary>
+    [TestMethod]
+    [ExpectedException(typeof(JsonException))]
+    public void DeserializeFromFile_InvalidJson_ThrowsJsonException()
+    {
+        var tempFilePath = Path.GetTempFileName();
+        File.WriteAllText(tempFilePath, "invalid json");
+
+        try
+        {
+            // This should throw JsonException
+            JsonMethods.DeserializeFromFile<TestObject>(tempFilePath);
+        }
+        finally
+        {
+            File.Delete(tempFilePath);
+        }
     }
 }

--- a/src/JSON/JSON.cs
+++ b/src/JSON/JSON.cs
@@ -1,4 +1,3 @@
-using System.IO;
 using System.Text.Json;
 
 namespace jmsudar.DotNet.JSON
@@ -9,36 +8,101 @@ namespace jmsudar.DotNet.JSON
     public static class JsonMethods
     {
         /// <summary>
-        /// Serializes an object to a JSON string representation
+        /// Serializes an object to its JSON string representation
         /// </summary>
         /// <param name="toSerialize">The object to serialize</param>
-        /// <param name="excludeNullFields">Whether or not the serializer should ignore null fields</param>
-        /// <returns>A JSON string representation of the object</returns>
-        public static string Serialize(object toSerialize, bool excludeNullFields = false) =>
+        /// <param name="prettify">Toggles human-readability and indentation</param>
+        /// <param name="excludeNullFields">Toggles whether or not the serializer should ignore null fields, defaults to false</param>
+        /// <returns>The object's JSON string representation</returns>
+        public static string Serialize(object toSerialize, bool prettify = false, bool excludeNullFields = false) =>
             JsonSerializer.Serialize(toSerialize, new JsonSerializerOptions()
+            {
+                WriteIndented = prettify,
+                IgnoreNullValues = excludeNullFields
+            });
+
+        /// <summary>
+        /// Serializes an object to a UTF-8 byte array of its JSON string representation
+        /// </summary>
+        /// <param name="toSerialize">The object to serialize</param>
+        /// <param name="excludeNullFields">Toggles whether or not the serializer should ignore null fields, defaults to false</param>
+        /// <returns>The UTF-8 byte array of the object's JSON string representation</returns>
+        public static byte[] SerializeToBytes(object toSerialize, bool excludeNullFields = false) =>
+            JsonSerializer.SerializeToUtf8Bytes(toSerialize, new JsonSerializerOptions()
             {
                 IgnoreNullValues = excludeNullFields
             });
 
         /// <summary>
-        /// Deserialize a JSON string into a generic object
+        /// Deserializes a JSON string into its generic object representation
         /// </summary>
         /// <typeparam name="T">The type of object being deserialized</typeparam>
         /// <param name="toDeserialize">The JSON string to deserialize</param>
+        /// <param name="caseInsensitive">Toggles case-insensitivity, defaults to true</param>
+        /// <param name="allowTrailingCommas">Toggles trailing comma allowance, defaults to true</param>
         /// <returns>The object representation of the JSON string</returns>
-        public static T Deserialize<T>(string toDeserialize) => JsonSerializer.Deserialize<T>(toDeserialize);
+        public static T Deserialize<T>(string toDeserialize, bool caseInsensitive = true, bool allowTrailingCommas = true) =>
+            JsonSerializer.Deserialize<T>(toDeserialize, new JsonSerializerOptions()
+            {
+                PropertyNameCaseInsensitive = caseInsensitive,
+                AllowTrailingCommas = allowTrailingCommas
+            });
 
         /// <summary>
-        /// Deserializes a .json file at a specified location
+        /// Deserializes the UTF-8 byte array of a JSON string into its generic object representation
+        /// </summary>
+        /// <typeparam name="T">The type of object being deserialized</typeparam>
+        /// <param name="toDeserialize">The JSON string to deserialize</param>
+        /// <param name="caseInsensitive">Toggles case-insensitivity, defaults to true</param>
+        /// <param name="allowTrailingCommas">Toggles trailing comma allowance, defaults to true</param>
+        /// <returns>The object representation of the JSON string's byte array</returns>
+        public static T Deserialize<T>(byte[] toDeserialize, bool caseInsensitive = true, bool allowTrailingCommas = true) =>
+            JsonSerializer.Deserialize<T>(toDeserialize, new JsonSerializerOptions()
+            {
+                PropertyNameCaseInsensitive = caseInsensitive,
+                AllowTrailingCommas = allowTrailingCommas
+            });
+
+        /// <summary>
+        /// Deserializes a .json file found at a specified location into its generic object representation
         /// </summary>
         /// <typeparam name="T">The type of object represented within the .json file</typeparam>
         /// <param name="filePath">The path to the file</param>
-        /// <returns>The object representation of the text within .json file</returns>
+        /// <returns>The object representation of the text within file</returns>
+        /// <exception cref="FileNotFoundException">Thrown when the file at the specified path does not exist</exception>
+        /// <exception cref="JsonException">Thrown when the file content is not in a valid JSON format</exception>
+        /// <exception cref="UnauthorizedAccessException">Thrown when the caller does not have the required permission</exception>
+        /// <exception cref="Exception">General exceptions for other issues, such as I/O errors</exception>
         public static T DeserializeFromFile<T>(string filePath)
         {
-            using (var reader = new StreamReader(filePath))
+            if (!File.Exists(filePath))
             {
-                return Deserialize<T>(reader.ReadToEnd());
+                throw new FileNotFoundException("The specified file was not found.", filePath);
+            }
+
+            try
+            {
+                using (var reader = new StreamReader(filePath))
+                {
+                    return Deserialize<T>(reader.ReadToEnd());
+                }
+            }
+            catch (JsonException ex)
+            {
+                // Handle JSON format issues
+                throw new JsonException("The file content is not in a valid JSON format.", ex);
+            }
+            // Not covered by unit tests due to environment by environment specificity of exception conditions
+            catch (UnauthorizedAccessException ex)
+            {
+                // Handle permission issues
+                throw new UnauthorizedAccessException("Access to the file is denied.", ex);
+            }
+            // Not covered by unit tests due to catch all nature of exception
+            catch (Exception ex)
+            {
+                // Handle other issues
+                throw new Exception($"An error occurred while reading the file: {ex.Message}", ex);
             }
         }
     }


### PR DESCRIPTION
# Overview

This PR builds out additional utilizations of `JsonSerializerOptions` in both the `Serialize` and `Deserialize` methods.
- Adds `prettify` parameter to utilize `WriteIndented` option
- Adds `caseInsensitive` to utilize `PropertyNameCaseInsensitive` option
- Adds `allowTrailingCommas` to utilize `AllowTrailingCommas` option

Adds support for serializing and deserializing `byte[]` objects in addition to the already supported strings.

Adds error handling for `DeserializeFromFile` to support possible error cases.
- File not found
- JSON formatting error
- Permissions issue
- Catch all and surfacing for un-specified errors

Unit tests covering all but the permissions issue and catch all error are included as well.

# Testing

<img width="734" alt="Screen Shot 2023-11-19 at 2 27 06 PM" src="https://github.com/jmsudar/DotNet-JSON/assets/11759458/cfc7e9d0-d4e3-4402-8413-90f6f00790e8">
