### PR TITLE
suppressed unneeded warnings in test file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### PR-8
+
+Adds several `pragma warning disable` and `restore` commands wrapping the unit test file to clean up unneeded warnings regarding potential null types that are the target of the tests themselves.
+
 ### PR-7
 
 Updates all references from `DotNet.JSON` to `DotNet.Json` to be in better keeping with .NET namespace best practices.

--- a/src/JSON.Tests/JSONTest.cs
+++ b/src/JSON.Tests/JSONTest.cs
@@ -18,6 +18,11 @@ public class JsonMethodsTests
         public int? Value { get; set; }
     }
 
+#pragma warning disable CS8600 // Suppressing CS8600
+#pragma warning disable CS8602 // Suppressing CS8602
+#pragma warning disable CS8603 // Suppressing CS8603
+#pragma warning disable CS8629 // Suppressing CS8629
+
     /// <summary>
     /// Tests Serialize method for returning valid JSON
     /// </summary>
@@ -233,4 +238,9 @@ public class JsonMethodsTests
             File.Delete(tempFilePath);
         }
     }
+
+#pragma warning restore CS8600 // Suppressing CS8600
+#pragma warning restore CS8602 // Suppressing CS8602
+#pragma warning restore CS8603 // Suppressing CS8603
+#pragma warning restore CS8629 // Suppressing CS8629
 }


### PR DESCRIPTION
# Overview

Adds several `pragma warning disable` and `restore` commands wrapping the unit test file to clean up unneeded warnings regarding potential null types that are the target of the tests themselves.