### PR TITLE
added nullability to solve last warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+### PR-10
+
+Adds nullability to generic return type in `DeserializeFromFile` method to address warning `CS8603`.
+
+Updates version, `1.1.0` => `1.2.0`
+
 ### PR-9
 
 Simple update to version number, `1.0.0` => `1.1.0`

--- a/src/JSON.Tests/JSONTest.cs
+++ b/src/JSON.Tests/JSONTest.cs
@@ -20,7 +20,6 @@ public class JsonMethodsTests
 
 #pragma warning disable CS8600 // Suppressing CS8600
 #pragma warning disable CS8602 // Suppressing CS8602
-#pragma warning disable CS8603 // Suppressing CS8603
 #pragma warning disable CS8629 // Suppressing CS8629
 
     /// <summary>
@@ -241,6 +240,6 @@ public class JsonMethodsTests
 
 #pragma warning restore CS8600 // Suppressing CS8600
 #pragma warning restore CS8602 // Suppressing CS8602
-#pragma warning restore CS8603 // Suppressing CS8603
 #pragma warning restore CS8629 // Suppressing CS8629
+
 }

--- a/src/JSON/JSON.cs
+++ b/src/JSON/JSON.cs
@@ -74,7 +74,7 @@ namespace jmsudar.DotNet.Json
         /// <exception cref="JsonException">Thrown when the file content is not in a valid JSON format</exception>
         /// <exception cref="UnauthorizedAccessException">Thrown when the caller does not have the required permission</exception>
         /// <exception cref="Exception">General exceptions for other issues, such as I/O errors</exception>
-        public static T DeserializeFromFile<T>(string filePath)
+        public static T? DeserializeFromFile<T>(string filePath)
         {
             if (!File.Exists(filePath))
             {

--- a/src/JSON/JSON.csproj
+++ b/src/JSON/JSON.csproj
@@ -5,7 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackageId>jmsudar.DotNet.Json</PackageId>
-    <Version>1.1.0</Version>
+    <Version>1.2.0</Version>
     <Authors>JM Sudar</Authors>
     <Description>A utility library for JSON serialization and deserialization.</Description>
     <PackageTags>json;serialization;deserialization</PackageTags>


### PR DESCRIPTION
# Overview

Adds nullability to generic return type in `DeserializeFromFile` method to address warning `CS8603`.

Updates version, `1.1.0` => `1.2.0`

# Testing

Ran `dotnet clean` and `dotnet build` to confirm build with no warnings.

<img width="721" alt="Screen Shot 2023-11-20 at 6 09 26 PM" src="https://github.com/jmsudar/DotNet.Json/assets/11759458/24ea0ed2-cf7a-48bd-92e4-c9f91311d7b6">

